### PR TITLE
added test for nested h-* values

### DIFF
--- a/tests/microformats-v2/h-entry/change-log.html
+++ b/tests/microformats-v2/h-entry/change-log.html
@@ -22,8 +22,13 @@
     <ul>
         <!-- Add change log event to the top of this list as a h-entry -->
         <li class="h-entry">
-            <span class="p-name e-content">Update text output to be textContent non-trimmed for summarycontent and urlcontent tests</span> &dash; 
-            <time class="dt-published" datetime="2014-05-29">29 May 2014</time> 
+            <span class="p-name e-content"></span>Added nestedvalue to test h-* property values, ensuring they take the first explicit "name" or "url" inside it. &dash;
+            <time class="dt-published" datetime="2014-05-30">30 May 2015</time>
+            by <span class="p-author">Kyle Mahan</span>
+        </li>
+        <li class="h-entry">
+            <span class="p-name e-content">Update text output to be textContent non-trimmed for summarycontent and urlcontent tests</span> &dash;
+            <time class="dt-published" datetime="2014-05-29">29 May 2014</time>
             by <span class="p-author">Glenn Jones</span>
         </li>
         <li class="h-entry">
@@ -58,7 +63,10 @@
     <ul>
         <!-- If you Contribute to the test please add yourself as an author using p-author h-card -->
         <li class="p-author h-card">
-           <a class="u-url p-name" rel="author" href="http://www.glennjones.net/">Glenn Jones</a> 
+           <a class="u-url p-name" rel="author" href="http://www.glennjones.net/">Glenn Jones</a>
+        </li>
+        <li class="p-author h-card">
+           <a class="u-url p-name" rel="author" href="https://kylewm.com/">Kyle Mahan</a>
         </li>
     </ul>
 

--- a/tests/microformats-v2/h-entry/nestedvalue.html
+++ b/tests/microformats-v2/h-entry/nestedvalue.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Nested complex h-* value parsing test</title>
+  </head>
+  <body>
+    <div class="h-entry">
+      <div class="u-in-reply-to h-cite">
+        <span class="p-author h-card"><span class="p-name">Example Author</span> <a class="u-url" href="http://example.com">Home</a></span>
+        <a class="p-name u-url" href="http://example.com/post">Example Post</a>
+      </div>
+    </div>
+  </body>
+</html>

--- a/tests/microformats-v2/h-entry/nestedvalue.json
+++ b/tests/microformats-v2/h-entry/nestedvalue.json
@@ -1,0 +1,26 @@
+{
+    "rels": {},
+    "items": [{
+        "type": ["h-entry"],
+        "properties": {
+            "in-reply-to": [{
+                "type": ["h-cite"],
+                "properties": {
+                    "name": ["Example Post"],
+                    "url": ["http://example.com/post"],
+
+                    "author": [{
+                        "type": ["h-card"],
+                        "properties": {
+                            "url": ["http://example.com"],
+                            "name": ["Example Author"]
+                        },
+                        "value": "Example Author"
+                    }]
+                },
+                "value": "http://example.com/post"
+            }],
+            "name": ["Example Author Home\n        Example Post"]
+        }
+    }]
+}


### PR DESCRIPTION
p-* h-* value should take on the first explicit "name" and
u-* h-* value should take on the first explicit "url".

http://microformats.org/wiki/microformats2-parsing-brainstorming#Nested_h-.2A_objects.27_.22value.22_property

cc: @tantek @kevinmarks 