### PR TITLE
Meta charset utf8

### DIFF
--- a/tests/microformats-mixed/h-resume/mixedroots.html
+++ b/tests/microformats-mixed/h-resume/mixedroots.html
@@ -1,3 +1,4 @@
+<meta charset="utf-8">
 <div class="h-resume">
     <div class="p-contact vcard">
         <p class="fn">Tim Berners-Lee</p>

--- a/tests/microformats-v1/geo/abbrpattern.html
+++ b/tests/microformats-v1/geo/abbrpattern.html
@@ -1,3 +1,4 @@
+<meta charset="utf-8">
 <p class="geo">
  <abbr class="latitude" title="37.408183">N 37° 24.491</abbr>,  
  <abbr class="longitude" title="-122.13855">W 122° 08.313</abbr>

--- a/tests/microformats-v1/geo/valuetitleclass.html
+++ b/tests/microformats-v1/geo/valuetitleclass.html
@@ -1,3 +1,4 @@
+<meta charset="utf-8">
 <p>
     <span class="geo">
         <span class="latitude">

--- a/tests/microformats-v1/hcalendar/attendees.html
+++ b/tests/microformats-v1/hcalendar/attendees.html
@@ -1,7 +1,8 @@
-<div class="vevent">       
-    <span class="summary">CPJ Online Press Freedom Summit</span> 
-    (<time class="dtstart" datetime="2012-10-10">10 Nov 2012</time>) in 
-    <span class="location">San Francisco</span>. 
+<meta charset="utf-8">
+<div class="vevent">
+    <span class="summary">CPJ Online Press Freedom Summit</span>
+    (<time class="dtstart" datetime="2012-10-10">10 Nov 2012</time>) in
+    <span class="location">San Francisco</span>.
     Attendees:
     <ul>
         <li class="attendee vcard">Brian Warner</li>

--- a/tests/microformats-v1/hentry/summarycontent.html
+++ b/tests/microformats-v1/hentry/summarycontent.html
@@ -1,3 +1,4 @@
+<meta charset="utf-8">
 <div class="hentry">
     <h1><a class="entry-title" href="http://microformats.org/2012/06/25/microformats-org-at-7">microformats.org at 7</a></h1>
     <div class="entry-content">

--- a/tests/microformats-v1/hproduct/aggregate.html
+++ b/tests/microformats-v1/hproduct/aggregate.html
@@ -1,3 +1,4 @@
+<meta charset="utf-8">
 <div class="hproduct">
     <h2 class="fn">Raspberry Pi</h2>
     <img class="photo" src="http://upload.wikimedia.org/wikipedia/commons/thumb/3/3d/RaspberryPi.jpg/320px-RaspberryPi.jpg" />

--- a/tests/microformats-v1/hproduct/simpleproperties.html
+++ b/tests/microformats-v1/hproduct/simpleproperties.html
@@ -1,3 +1,4 @@
+<meta charset="utf-8">
 <div class="hproduct">
     <h2 class="fn">Raspberry Pi</h2>
     <img class="photo" src="http://upload.wikimedia.org/wikipedia/commons/thumb/3/3d/RaspberryPi.jpg/320px-RaspberryPi.jpg" />

--- a/tests/microformats-v1/hresume/work.html
+++ b/tests/microformats-v1/hresume/work.html
@@ -1,3 +1,4 @@
+<meta charset="utf-8">
 <div class="hresume">
     <div class="contact vcard">
         <p class="fn">Tim Berners-Lee</p>

--- a/tests/microformats-v1/includes/table.html
+++ b/tests/microformats-v1/includes/table.html
@@ -1,3 +1,4 @@
+<meta charset="utf-8">
 <table>
     <tr>
         <th id="org"><a class="url org" href="http://dev.opera.com/">Opera</a></th>

--- a/tests/microformats-v2/h-card/childimplied.html
+++ b/tests/microformats-v2/h-card/childimplied.html
@@ -1,3 +1,4 @@
+<meta charset="utf-8">
 <a class="h-card" href="http://people.opera.com/howcome/" title="Håkon Wium Lie, CTO Opera">
   <article>
      <h2 class="p-name">Håkon Wium Lie</h2>

--- a/tests/microformats-v2/h-entry/summarycontent.html
+++ b/tests/microformats-v2/h-entry/summarycontent.html
@@ -1,3 +1,4 @@
+<meta charset="utf-8">
 <div class="h-entry">
     <h1><a class="p-name u-url" href="http://microformats.org/2012/06/25/microformats-org-at-7">microformats.org at 7</a></h1>
     <div class="e-content">

--- a/tests/microformats-v2/h-event/attendees.html
+++ b/tests/microformats-v2/h-event/attendees.html
@@ -1,7 +1,8 @@
-<div class="h-event">       
-    <span class="p-name">CPJ Online Press Freedom Summit</span> 
-    (<time class="dt-start" datetime="2012-10-10">10 Nov 2012</time>) in 
-    <span class="p-location">San Francisco</span>. 
+<meta charset="utf-8">
+<div class="h-event">
+    <span class="p-name">CPJ Online Press Freedom Summit</span>
+    (<time class="dt-start" datetime="2012-10-10">10 Nov 2012</time>) in
+    <span class="p-location">San Francisco</span>.
     Attendees:
     <ul>
         <li class="p-attendee h-card">Brian Warner</li>

--- a/tests/microformats-v2/h-geo/abbrpattern.html
+++ b/tests/microformats-v2/h-geo/abbrpattern.html
@@ -1,3 +1,4 @@
+<meta charset="utf-8">
 <p class="h-geo">
  <abbr class="p-latitude" title="37.408183">N 37° 24.491</abbr>,  
  <abbr class="p-longitude" title="-122.13855">W 122° 08.313</abbr>

--- a/tests/microformats-v2/h-geo/valuetitleclass.html
+++ b/tests/microformats-v2/h-geo/valuetitleclass.html
@@ -1,3 +1,4 @@
+<meta charset="utf-8">
 <p>
     <span class="h-geo">
         <span class="p-latitude">

--- a/tests/microformats-v2/h-product/aggregate.html
+++ b/tests/microformats-v2/h-product/aggregate.html
@@ -1,3 +1,4 @@
+<meta charset="utf-8">
 <div class="h-product">
     <h2 class="p-name">Raspberry Pi</h2>
     <img class="u-photo" src="http://upload.wikimedia.org/wikipedia/commons/thumb/3/3d/RaspberryPi.jpg/320px-RaspberryPi.jpg" />

--- a/tests/microformats-v2/h-product/simpleproperties.html
+++ b/tests/microformats-v2/h-product/simpleproperties.html
@@ -1,3 +1,4 @@
+<meta charset="utf-8">
 <div class="h-product">
     <h2 class="p-name">Raspberry Pi</h2>
     <img class="u-photo" src="http://upload.wikimedia.org/wikipedia/commons/thumb/3/3d/RaspberryPi.jpg/320px-RaspberryPi.jpg" />

--- a/tests/microformats-v2/h-resume/work.html
+++ b/tests/microformats-v2/h-resume/work.html
@@ -1,3 +1,4 @@
+<meta charset="utf-8">
 <div class="h-resume">
     <p class="p-name">Tim Berners-Lee</p>
     <div class="p-contact h-card">


### PR DESCRIPTION
discussed in #30, there is a bit of an issue in that the testsuite uses snips of HTML and loses some context compared to a real published document, in this case the Content-Type. For these files with international characters, let's try adding the charset explicitly at the top of the file.