### PR TITLE
Remove HTML entity to stop encoding issue

### DIFF
--- a/tests/microformats-v2/rel/duplicate-rels.html
+++ b/tests/microformats-v2/rel/duplicate-rels.html
@@ -5,6 +5,6 @@
 <span class="author vcard">
 <a class="url fn n" href="http://ma.tt/author/saxmatt/" 
     title="View all posts by Matt" rel="author">Matt</a></span>
-<span class="date"><a href="http://ma.tt/2015/06/jefferson-on-idleness/" title="Permalink to Jefferson on&nbsp;Idleness" rel="bookmark"><time class="entry-date" datetime="2015-06-02T21:26:00+00:00">June 2, 2015</time></a></span>
+<span class="date"><a href="http://ma.tt/2015/06/jefferson-on-idleness/" title="Permalink to Jefferson on Idleness" rel="bookmark"><time class="entry-date" datetime="2015-06-02T21:26:00+00:00">June 2, 2015</time></a></span>
 <span class="categories-links"><a href="http://ma.tt/category/asides/" rel="category tag">Asides</a></span>
 <span class="author vcard"><a class="url fn n" href="http://ma.tt/author/saxmatt/" title="View all posts by Matt" rel="author">Matt</a></span>

--- a/tests/microformats-v2/rel/duplicate-rels.json
+++ b/tests/microformats-v2/rel/duplicate-rels.json
@@ -69,7 +69,7 @@
                 "bookmark"
             ], 
             "text": "June 2, 2015", 
-            "title": "Permalink to Jefferson on\u00a0Idleness"
+            "title": "Permalink to Jefferson on Idleness"
         }
     }
 }


### PR DESCRIPTION
The parsers process HTML entities such as `&nbsp;` differently. The resulting encoding would need to be normalised to be tested correctly. For the time the HTML entities have been removed from tests.