### PR TITLE
value-class-pattern should not insert space

### DIFF
--- a/tests/microformats-v2/h-card/p-property.json
+++ b/tests/microformats-v2/h-card/p-property.json
@@ -2,7 +2,7 @@
     "items": [{
         "type": ["h-card"],
         "properties": {
-            "name": ["John Doe"],
+            "name": ["JohnDoe"],
             "given-name": ["John"],
             "additional-name": ["Peter"],
             "family-name": ["Doe"],


### PR DESCRIPTION
From http://microformats.org/wiki/value-class-pattern#Basic_Parsing:

> 3\. Where there are multiple descendants of a property with class name of value (multiple value elements)
>     1. if the microformats property expects a simple string, enumerated value, or telephone number, then the values extracted from the value elements should be concatenated without inserting additional characters or white-space.

php-mf2, mf2py, and gomf all agree on the expected value here:
 - http://pin13.net/mf2/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmicroformats%2Ftests%2Fmaster%2Ftests%2Fmicroformats-v2%2Fh-card%2Fp-property.html
 - http://mf2.kylewm.com/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmicroformats%2Ftests%2Fmaster%2Ftests%2Fmicroformats-v2%2Fh-card%2Fp-property.html&parser=html5lib
 - https://willnorris.com/go/microformats/live?url=https://raw.githubusercontent.com/microformats/tests/master/tests/microformats-v2/h-card/p-property.html

I suspect there may be other tests affected by this as well, in which case I guess I'll fix them as I find them.