### PR TITLE
impliedname: remove 'value' in nested microformat

### DIFF
--- a/tests/microformats-v2/h-card/impliedname.json
+++ b/tests/microformats-v2/h-card/impliedname.json
@@ -78,7 +78,6 @@
             "name": ["Name"]
         },
         "children": [{
-            "value": "Name",
             "type": ["h-card"],
             "properties": {
                 "name": ["John Doe"],


### PR DESCRIPTION
This commit only removes the single instance of an errant `value` field in the impliedname test case.  There very well may be more, but I don't have an easy way of testing for them right now (they're masked by other errors I have in the go library).  I suspect the best approach would be to fix the node library to handle this one case properly and then see what other tests get broken in the process, which will _probably_ other cases of the same problem.

Fixes #51 
