### PR TITLE
Address WARN package.json microformat-tests@0.1.26 license should be a valid SPDX license expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "microformat-tests",
   "description": "A microformat 2 testsuite",
   "version": "0.1.26",
-  "license": "Public Domain",
+  "license": "CC0-1.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/microformats/tests.git"


### PR DESCRIPTION
Hi Folks,
Getting to grips with the tests I am seeing a few things which need fixing, so just sending in PR's as I see issues.
This one is trivial, however there are still a couple of issues,

Firstly when I attempt to follow the [npm](https://github.com/microformats/tests#npm) instructions, I get the following
```
lmcgibbn@LMC-056430 /usr/local/tests(master) $ npm i microformats-tests --save
npm WARN package.json microformat-tests@0.1.26 license should be a valid SPDX license expression
npm ERR! Darwin 15.6.0
npm ERR! argv "/Users/lmcgibbn/miniconda3/bin/node" "/Users/lmcgibbn/miniconda3/bin/npm" "i" "microformats-tests" "--save"
npm ERR! node v4.5.0
npm ERR! npm  v2.15.9

npm ERR! Cannot convert undefined or null to object
npm ERR!
npm ERR! If you need help, you may report this error at:
npm ERR!     <https://github.com/npm/npm/issues>

npm ERR! Please include the following file with any support request:
npm ERR!     /usr/local/tests/npm-debug.log
```
Note that the following WARN disappears when the PR is applied
```
npm WARN package.json microformat-tests@0.1.26 license should be a valid SPDX license expression
```
My debug log looks as follows
```
0 info it worked if it ends with ok
1 verbose cli [ '/Users/lmcgibbn/miniconda3/bin/node',
1 verbose cli   '/Users/lmcgibbn/miniconda3/bin/npm',
1 verbose cli   'i',
1 verbose cli   'microformats-tests',
1 verbose cli   '--save' ]
2 info using npm@2.15.9
3 info using node@v4.5.0
4 verbose install initial load of /usr/local/tests/package.json
5 verbose readDependencies loading dependencies from /usr/local/tests/package.json
6 silly cache add args [ 'microformats-tests', null ]
7 verbose cache add spec microformats-tests
8 silly cache add parsed spec Result {
8 silly cache add   raw: 'microformats-tests',
8 silly cache add   scope: null,
8 silly cache add   name: 'microformats-tests',
8 silly cache add   rawSpec: '',
8 silly cache add   spec: 'latest',
8 silly cache add   type: 'tag' }
9 silly addNamed microformats-tests@latest
10 verbose addNamed "latest" is being treated as a dist-tag for microformats-tests
11 info addNameTag [ 'microformats-tests', 'latest' ]
12 silly mapToRegistry name microformats-tests
13 silly mapToRegistry using default registry
14 silly mapToRegistry registry https://registry.npmjs.org/
15 silly mapToRegistry data Result {
15 silly mapToRegistry   raw: 'microformats-tests',
15 silly mapToRegistry   scope: null,
15 silly mapToRegistry   name: 'microformats-tests',
15 silly mapToRegistry   rawSpec: '',
15 silly mapToRegistry   spec: 'latest',
15 silly mapToRegistry   type: 'tag' }
16 silly mapToRegistry uri https://registry.npmjs.org/microformats-tests
17 verbose addNameTag registry:https://registry.npmjs.org/microformats-tests not in flight; fetching
18 verbose request uri https://registry.npmjs.org/microformats-tests
19 verbose request no auth needed
20 info attempt registry request try #1 at 18:04:16
21 verbose request id 6f8ce16e0cc0ed97
22 verbose etag W/"555f413d-1aa"
23 verbose lastModified Fri, 22 May 2015 14:46:21 GMT
24 http request GET https://registry.npmjs.org/microformats-tests
25 http 304 https://registry.npmjs.org/microformats-tests
26 verbose headers { date: 'Thu, 30 Mar 2017 01:04:09 GMT',
26 verbose headers   via: '1.1 varnish',
26 verbose headers   'cache-control': 'max-age=300',
26 verbose headers   etag: 'W/"555f413d-1aa"',
26 verbose headers   age: '0',
26 verbose headers   connection: 'keep-alive',
26 verbose headers   'x-served-by': 'cache-lax8625-LAX',
26 verbose headers   'x-cache': 'HIT',
26 verbose headers   'x-cache-hits': '1',
26 verbose headers   'x-timer': 'S1490835849.794238,VS0,VE160',
26 verbose headers   vary: 'Accept-Encoding' }
27 silly get cb [ 304,
27 silly get   { date: 'Thu, 30 Mar 2017 01:04:09 GMT',
27 silly get     via: '1.1 varnish',
27 silly get     'cache-control': 'max-age=300',
27 silly get     etag: 'W/"555f413d-1aa"',
27 silly get     age: '0',
27 silly get     connection: 'keep-alive',
27 silly get     'x-served-by': 'cache-lax8625-LAX',
27 silly get     'x-cache': 'HIT',
27 silly get     'x-cache-hits': '1',
27 silly get     'x-timer': 'S1490835849.794238,VS0,VE160',
27 silly get     vary: 'Accept-Encoding' } ]
28 verbose etag https://registry.npmjs.org/microformats-tests from cache
29 verbose get saving microformats-tests to /Users/lmcgibbn/.npm/registry.npmjs.org/microformats-tests/.cache.json
30 verbose correctMkdir /Users/lmcgibbn/.npm correctMkdir not in flight; initializing
31 silly addNameTag next cb for microformats-tests with tag latest
32 verbose stack TypeError: Cannot convert undefined or null to object
32 verbose stack     at Function.keys (native)
32 verbose stack     at installTargetsError (/Users/lmcgibbn/miniconda3/lib/node_modules/npm/lib/cache/add-named.js:273:24)
32 verbose stack     at next (/Users/lmcgibbn/miniconda3/lib/node_modules/npm/lib/cache/add-named.js:94:10)
32 verbose stack     at RES (/Users/lmcgibbn/miniconda3/lib/node_modules/npm/node_modules/inflight/inflight.js:23:14)
32 verbose stack     at f (/Users/lmcgibbn/miniconda3/lib/node_modules/npm/node_modules/once/once.js:17:25)
32 verbose stack     at fixName (/Users/lmcgibbn/miniconda3/lib/node_modules/npm/lib/cache/add-named.js:29:5)
32 verbose stack     at saved (/Users/lmcgibbn/miniconda3/lib/node_modules/npm/lib/cache/caching-client.js:173:7)
32 verbose stack     at /Users/lmcgibbn/miniconda3/lib/node_modules/npm/node_modules/graceful-fs/polyfills.js:210:7
32 verbose stack     at FSReqWrap.oncomplete (fs.js:82:15)
33 verbose cwd /usr/local/tests
34 error Darwin 15.6.0
35 error argv "/Users/lmcgibbn/miniconda3/bin/node" "/Users/lmcgibbn/miniconda3/bin/npm" "i" "microformats-tests" "--save"
36 error node v4.5.0
37 error npm  v2.15.9
38 error Cannot convert undefined or null to object
39 error If you need help, you may report this error at:
39 error     <https://github.com/npm/npm/issues>
40 verbose exit [ 1, true ]
```
When I attempt to GET https://registry.npmjs.org/microformats-tests, the following results
```
{
  "_id": "microformats-tests",
  "_rev": "2-b625d4c89773484bae2525f915d4e128",
  "name": "microformats-tests",
  "time": {
    "modified": "2015-05-22T14:46:21.934Z",
    "created": "2015-05-22T14:46:21.934Z",
    "0.1.0": "2015-05-22T14:46:21.934Z",
    "unpublished": {
      "name": "glennjones",
      "time": "2015-05-22T14:53:28.912Z",
      "tags": {
        "latest": "0.1.0"
      },
      "maintainers": [
        {
          "name": "glennjones",
          "email": "glennjonesnet@gmail.com"
        }
      ],
      "versions": [
        "0.1.0"
      ]
    }
  },
  "_attachments": {
    
  }
}
```
It would appear that the npm documentation requires an update. Any ideas?