### PR TITLE
fix two issues in duplicate-rels test case

### DIFF
--- a/tests/microformats-v2/rel/duplicate-rels.html
+++ b/tests/microformats-v2/rel/duplicate-rels.html
@@ -2,9 +2,9 @@
     title="Permalink to Beethoven, Mozart, Bach" rel="bookmark">
 <time class="entry-date" datetime="2015-05-31T22:42:00+00:00">May 31, 2015</time></a></span>
 <a href="http://ma.tt/category/asides/" rel="category tag">Asides</a>
-<span class="author vcard">
+<span class="author h-card">
 <a class="url fn n" href="http://ma.tt/author/saxmatt/" 
     title="View all posts by Matt" rel="author">Matt</a></span>
 <span class="date"><a href="http://ma.tt/2015/06/jefferson-on-idleness/" title="Permalink to Jefferson on Idleness" rel="bookmark"><time class="entry-date" datetime="2015-06-02T21:26:00+00:00">June 2, 2015</time></a></span>
 <span class="categories-links"><a href="http://ma.tt/category/asides/" rel="category tag">Asides</a></span>
-<span class="author vcard"><a class="url fn n" href="http://ma.tt/author/saxmatt/" title="View all posts by Matt" rel="author">Matt</a></span>
+<span class="author h-card"><a class="url fn n" href="http://ma.tt/author/saxmatt/" title="View all posts by Matt" rel="author">Matt</a></span>

--- a/tests/microformats-v2/rel/duplicate-rels.json
+++ b/tests/microformats-v2/rel/duplicate-rels.json
@@ -61,7 +61,7 @@
             "rels": [
                 "bookmark"
             ], 
-            "text": "May 31, 2015", 
+            "text": "\nMay 31, 2015",
             "title": "Permalink to Beethoven, Mozart, Bach"
         }, 
         "http://ma.tt/2015/06/jefferson-on-idleness/": {


### PR DESCRIPTION
- hcard for author should use microformats2 root class names, since this
  is part of the microformats2 test suite.
- retain surrounding whitespace when parsing text value of a rel
  microformat.