### PR TITLE
Add test case using href="" in url property to reference current page

### DIFF
--- a/tests/microformats-v2/h-card/change-log.html
+++ b/tests/microformats-v2/h-card/change-log.html
@@ -21,6 +21,11 @@
     <h2>Change log:</h2>
     <ul>
         <!-- Add change log event to the top of this list as a h-entry -->
+		<li class="h-entry">
+            <span class="p-name e-content">Added test using empty href="" attribute to reference current page</span> &dash; 
+            <time class="dt-published" datetime="2017-05-27">27 May 2017</time> 
+            by <span class="p-author">Sven Knebel</span>
+        </li>
         <li class="h-entry">
             <span class="p-name e-content">Changed the order of items in type property for nested tests</span> &dash; 
             <time class="dt-published" datetime="2015-05-23">23 May 2015</time> 
@@ -88,6 +93,9 @@
         <li class="p-author h-card">
            <a class="u-url p-name" rel="author" href="http://www.glennjones.net/">Glenn Jones</a> 
         </li>
+		<li class="p-author h-card">
+		   <a class="u-url p-name" rel="author" href="https://www.svenknebel.de/">Sven Knebel</a>
+		</li>
     </ul>
 
         

--- a/tests/microformats-v2/h-card/change-log.html
+++ b/tests/microformats-v2/h-card/change-log.html
@@ -22,6 +22,11 @@
     <ul>
         <!-- Add change log event to the top of this list as a h-entry -->
 		<li class="h-entry">
+            <span class="p-name e-content">Added test for empty href="" attribute in implied property</span> &dash; 
+            <time class="dt-published" datetime="2017-06-3">3 June 2017</time> 
+            by <span class="p-author">Sven Knebel</span>
+        </li>
+		<li class="h-entry">
             <span class="p-name e-content">Added test using empty href="" attribute to reference current page</span> &dash; 
             <time class="dt-published" datetime="2017-05-27">27 May 2017</time> 
             by <span class="p-author">Sven Knebel</span>

--- a/tests/microformats-v2/h-card/impliedurlempty.html
+++ b/tests/microformats-v2/h-card/impliedurlempty.html
@@ -1,0 +1,5 @@
+<a class="h-card" href="">Jane Doe</a>
+<area class="h-card" href="" alt="Jane Doe"/ >
+<div class="h-card" ><a href="">Jane Doe</a><p></p></div> 
+<div class="h-card" ><area href="">Jane Doe</area><p></p></div>
+<div class="h-card" ><a class="h-card" href="">Jane Doe</a><p></p></div> 

--- a/tests/microformats-v2/h-card/impliedurlempty.json
+++ b/tests/microformats-v2/h-card/impliedurlempty.json
@@ -1,0 +1,45 @@
+{
+    "items": [{
+        "type": ["h-card"],
+        "properties": {
+            "name": ["Jane Doe"],
+            "url": ["http://example.com/"]
+        }
+    },
+    {
+        "type": ["h-card"],
+        "properties": {
+            "name": ["Jane Doe"],
+            "url": ["http://example.com/"]
+        }
+    },
+    {
+        "type": ["h-card"],
+        "properties": {
+            "name": ["Jane Doe"],
+            "url": ["http://example.com/"]
+        }
+    },
+    {
+        "type": ["h-card"],
+        "properties": {
+            "name": ["Jane Doe"],
+            "url": ["http://example.com/"]
+        }
+    },
+    {
+        "type": ["h-card"],
+        "properties": {
+            "name": ["Jane Doe"]
+        },
+        "children": [{
+            "type": ["h-card"],
+            "properties": {
+                "name": ["Jane Doe"],
+                "url": ["http://example.com/"]
+            }
+        }]
+    }],
+    "rels": {},
+    "rel-urls": {}
+}

--- a/tests/microformats-v2/h-card/relativeurlsempty.html
+++ b/tests/microformats-v2/h-card/relativeurlsempty.html
@@ -1,0 +1,4 @@
+<base href="http://example.com/profile">
+<div class="h-card">
+  <a class="p-name u-url u-uid" href="">Max Mustermann</a> 
+</div>

--- a/tests/microformats-v2/h-card/relativeurlsempty.json
+++ b/tests/microformats-v2/h-card/relativeurlsempty.json
@@ -1,0 +1,22 @@
+{
+    "items": [
+        {
+            "type": [
+                "h-card"
+            ],
+            "properties": {
+                "name": [
+                    "Max Mustermann"
+                ],
+                "url": [
+                    "http://example.com/profile"
+                ],
+                "uid": [
+                    "http://example.com/profile"
+                ]
+            }
+        }
+    ],
+    "rels": {},
+    "rel-urls": {}
+}


### PR DESCRIPTION
Covering issues (https://github.com/indieweb/php-mf2/issues/118, https://github.com/glennjones/microformat-shiv/issues/30) where parser treat empty attributes the same as if the attribute didn't exist. Especially noticable on h-cards, which often refer to the current page with a relative URL of "".