### PR TITLE
Update self-closing p-* properties test results

### DIFF
--- a/tests/microformats-v2/h-card/p-property.json
+++ b/tests/microformats-v2/h-card/p-property.json
@@ -6,7 +6,7 @@
             "given-name": ["John"],
             "additional-name": ["Peter"],
             "family-name": ["Doe"],
-            "honorific-suffix": ["MSc", "PHD"],
+            "honorific-suffix": ["MSc", "", "", "PHD"],
             "org": ["Madgex", "Mozilla"]
         }
     }],


### PR DESCRIPTION
@dissolve reported this one in #75 based on [issue #72 in the microformats/microformats-ruby repo](https://github.com/microformats/microformats-ruby/issues/72). The [relevant conclusion](https://github.com/microformats/microformats-ruby/issues/72#issuecomment-303815441) from that thread is:

> Thanks to @domenic (i'm assuming since same name on IRC), it is generally understood that the concatination of the null set is the empty string. This would mean nokogiri is correct and the test suite is incorrect.

Accordingly, this change adds two empty strings to the `honorific-suffix` result array, resolving #75.