### PR TITLE
expand implied photo URL to absolute URL

### DIFF
--- a/tests/microformats-v2/h-card/impliedname.json
+++ b/tests/microformats-v2/h-card/impliedname.json
@@ -101,7 +101,7 @@
         "type": ["h-card"],
         "properties": {
             "name": ["John Doe Jr."],
-            "photo": ["/photo.jpg"]
+            "photo": ["http://example.com/photo.jpg"]
         }
     }],
     "rels": {},


### PR DESCRIPTION
From http://microformats.org/wiki/microformats2-parsing#parsing_for_implied_properties:

> if there is a gotten photo value, return the normalized absolute URL of it, following the containing document's language's rules for resolving relative URLs (e.g. in HTML, use the current URL context as determined by the page, and first <base> element, if any).