### PR TITLE
include img.src in e-* value property

### DIFF
--- a/tests/microformats-v2/h-entry/urlincontent.json
+++ b/tests/microformats-v2/h-entry/urlincontent.json
@@ -4,7 +4,7 @@
         "properties": {
             "name": ["Expanding URLs within HTML content"],
             "content": [{
-                "value": "Should not change: http://www.w3.org/\n            Should not change: http://example.com/\n            File relative: test.html = http://example.com/test.html\n            Directory relative: /test/test.html = http://example.com/test/test.html\n            Relative to root: /test.html = http://example.com/test.html",
+                "value": "Should not change: http://www.w3.org/\n            Should not change: http://example.com/\n            File relative: test.html = http://example.com/test.html\n            Directory relative: /test/test.html = http://example.com/test/test.html\n            Relative to root: /test.html = http://example.com/test.html\n         http://example.com/images/photo.gif",
                 "html": "<ul>\n            <li><a href=\"http://www.w3.org/\">Should not change: http://www.w3.org/</a></li>\n            <li><a href=\"http://example.com/\">Should not change: http://example.com/</a></li>\n            <li><a href=\"http://example.com/test.html\">File relative: test.html = http://example.com/test.html</a></li>\n            <li><a href=\"http://example.com/test/test.html\">Directory relative: /test/test.html = http://example.com/test/test.html</a></li>\n            <li><a href=\"http://example.com/test.html\">Relative to root: /test.html = http://example.com/test.html</a></li>\n        </ul>\n        <img src=\"http://example.com/images/photo.gif\" />"
             }]
         }


### PR DESCRIPTION
the parsing spec [calls for](http://microformats.org/wiki/microformats2-parsing#parsing_an_e-_property) including the src attribute of an img tag if there is no alt attribute:

> replacing any nested `<img>` elements with their alt attribute, if present; otherwise their src attribute, if present, adding a space at the beginning and end, resolving the URL if it’s relative;

According to <https://ben.thatmustbe.me/mf2tests/>, the go, php, and python parsers all include the img.src (and are therefore failing this test).

