### PR TITLE
parse hproduct description as p-description not e-description

### DIFF
--- a/tests/microformats-v1/hproduct/aggregate.json
+++ b/tests/microformats-v1/hproduct/aggregate.json
@@ -4,10 +4,7 @@
         "properties": {
             "name": ["Raspberry Pi"],
             "photo": ["http://upload.wikimedia.org/wikipedia/commons/thumb/3/3d/RaspberryPi.jpg/320px-RaspberryPi.jpg"],
-            "description": [{
-                "value": "The Raspberry Pi is a credit-card sized computer that plugs into your TV and a keyboard. It’s a capable little PC which can be used for many of the things that your desktop PC does, like spreadsheets, word-processing and games. It also plays high-definition video. We want to see it being used by kids all over the world to learn programming.",
-                "html": "The Raspberry Pi is a credit-card sized computer that plugs into your TV and a keyboard. It’s a capable little PC which can be used for many of the things that your desktop PC does, like spreadsheets, word-processing and games. It also plays high-definition video. We want to see it being used by kids all over the world to learn programming."
-            }],
+            "description": [ "The Raspberry Pi is a credit-card sized computer that plugs into your TV and a keyboard. It’s a capable little PC which can be used for many of the things that your desktop PC does, like spreadsheets, word-processing and games. It also plays high-definition video. We want to see it being used by kids all over the world to learn programming." ],
             "url": ["http://www.raspberrypi.org/"],
             "price": ["£29.95"],
             "review": [{


### PR DESCRIPTION
as per http://microformats.org/wiki/h-product#Backward_Compatibility
description in backcompat mode should be parsed as p- not e-

this completes the change made in 13f97611 for the simpleproperties test