### PR TITLE
don't reformat v1 datetime values not using vcp

### DIFF
--- a/tests/microformats-v1/hcard/single.json
+++ b/tests/microformats-v1/hcard/single.json
@@ -5,7 +5,7 @@
             "name": ["John Doe"],
             "given-name": ["John"],
             "sort-string": ["John"],
-            "bday": ["2000-01-01 00:00:00-08:00"],
+            "bday": ["2000-01-01T00:00:00-08:00"],
             "role": ["Designer"],
             "geo": [{
                 "value": "30.267991;-97.739568",
@@ -15,7 +15,7 @@
             "tz": ["-05:00"],
             "uid": ["http://example.com/profiles/johndoe"],
             "class": ["Public"],
-            "rev": ["2008-01-01 13:45:00"]
+            "rev": ["2008-01-01T13:45:00"]
         }
     }],
     "rels": {},

--- a/tests/microformats-v1/hentry/summarycontent.json
+++ b/tests/microformats-v1/hentry/summarycontent.json
@@ -8,7 +8,7 @@
                 "html": "\n        <p class=\"entry-summary\">Last week the microformats.org community \n            celebrated its 7th birthday at a gathering hosted by Mozilla in \n            San Francisco and recognized accomplishments, challenges, and \n            opportunities.</p>\n\n        <p>The microformats tagline “humans first, machines second” \n            forms the basis of many of our \n            <a href=\"http://microformats.org/wiki/principles\">principles</a>, and \n            in that regard, we’d like to recognize a few people and \n            thank them for their years of volunteer service </p>\n"
             }],
             "summary": ["Last week the microformats.org community \n            celebrated its 7th birthday at a gathering hosted by Mozilla in \n            San Francisco and recognized accomplishments, challenges, and \n            opportunities."],
-            "updated": ["2012-06-25 17:08:26"],
+            "updated": ["2012-06-25T17:08:26"],
             "author": [{
                 "value": "Tantek",
                 "type": ["h-card"],

--- a/tests/microformats-v1/hfeed/simple.json
+++ b/tests/microformats-v1/hfeed/simple.json
@@ -24,7 +24,7 @@
                     "html": "\n\t        <p class=\"entry-summary\">Last week the microformats.org community \n\t            celebrated its 7th birthday at a gathering hosted by Mozilla in \n\t            San Francisco and recognized accomplishments, challenges, and \n\t            opportunities.</p>\n\t\n\t        <p>The microformats tagline “humans first, machines second” \n\t            forms the basis of many of our \n\t            <a href=\"http://microformats.org/wiki/principles\">principles</a>, and \n\t            in that regard, we’d like to recognize a few people and \n\t            thank them for their years of volunteer service </p>\n\t"
                 }],
                 "summary": ["Last week the microformats.org community \n\t            celebrated its 7th birthday at a gathering hosted by Mozilla in \n\t            San Francisco and recognized accomplishments, challenges, and \n\t            opportunities."],
-                "updated": ["2012-06-25 17:08:26"]
+                "updated": ["2012-06-25T17:08:26"]
             }
         }]
     }],

--- a/tests/microformats-v1/hnews/all.json
+++ b/tests/microformats-v1/hnews/all.json
@@ -14,7 +14,7 @@
             "html": "\n            <p class=\"entry-summary\">Last week the microformats.org community \n                celebrated its 7th birthday at a gathering hosted by Mozilla in \n                San Francisco and recognized accomplishments, challenges, and \n                opportunities.</p>\n\n            <p>The microformats tagline “humans first, machines second” \n                forms the basis of many of our \n                <a href=\"http://microformats.org/wiki/principles\">principles</a>, and \n                in that regard, we’d like to recognize a few people and \n                thank them for their years of volunteer service </p>\n"
           }],
           "summary": ["Last week the microformats.org community \n                celebrated its 7th birthday at a gathering hosted by Mozilla in \n                San Francisco and recognized accomplishments, challenges, and \n                opportunities."],
-          "updated": ["2012-06-25 17:08:26"],
+          "updated": ["2012-06-25T17:08:26"],
           "author": [{
             "value": "Tantek",
             "type": ["h-card"],

--- a/tests/microformats-v1/hnews/minimum.json
+++ b/tests/microformats-v1/hnews/minimum.json
@@ -14,7 +14,7 @@
             "html": "\n            <p class=\"entry-summary\">Last week the microformats.org community \n                celebrated its 7th birthday at a gathering hosted by Mozilla in \n                San Francisco and recognized accomplishments, challenges, and \n                opportunities.</p>\n\n            <p>The microformats tagline “humans first, machines second” \n                forms the basis of many of our \n                <a href=\"http://microformats.org/wiki/principles\">principles</a>, and \n                in that regard, we’d like to recognize a few people and \n                thank them for their years of volunteer service </p>\n"
           }],
           "summary": ["Last week the microformats.org community \n                celebrated its 7th birthday at a gathering hosted by Mozilla in \n                San Francisco and recognized accomplishments, challenges, and \n                opportunities."],
-          "updated": ["2012-06-25 17:08:26"],
+          "updated": ["2012-06-25T17:08:26"],
           "author": [{
             "value": "Tantek",
             "type": ["h-card"],

--- a/tests/microformats-v1/includes/object.json
+++ b/tests/microformats-v1/includes/object.json
@@ -2,7 +2,7 @@
     "items": [{
         "type": ["h-event"],
         "properties": {
-            "start": ["2012-10-30 11:45:00-08:00"],
+            "start": ["2012-10-30T11:45:00-08:00"],
             "name": ["Build Conference"],
             "location": [{
                 "value": "Redmond, \n        Washington, \n        USA",
@@ -17,7 +17,7 @@
     }, {
         "type": ["h-event"],
         "properties": {
-            "start": ["2012-10-31 11:15:00-08:00"],
+            "start": ["2012-10-31T11:15:00-08:00"],
             "name": ["Build Conference"],
             "location": [{
                 "value": "Redmond, \n        Washington, \n        USA",


### PR DESCRIPTION
datetime values should only be parsed and reformatted if specified using
the value class pattern.

See related commits: 8db82c7, 070c19d

See also related discussion in https://github.com/microformats/microformats2-parsing/issues/12, but that proposal has not yet been accepted.