### PR TITLE
update tests to always resolve relative URLs

### DIFF
--- a/tests/microformats-v1/hcard/email.json
+++ b/tests/microformats-v1/hcard/email.json
@@ -3,7 +3,7 @@
         "type": ["h-card"],
         "properties": {
             "name": ["John Doe"],
-            "email": ["mailto:john@example.com", "john@example.com", "mailto:john@example.com?subject=parser-test", "john@example.com"]
+            "email": ["mailto:john@example.com", "http://example.com/john@example.com", "mailto:john@example.com?subject=parser-test", "http://example.com/john@example.com"]
         }
     }],
     "rels": {},

--- a/tests/microformats-v2/h-card/relativeurlsempty.html
+++ b/tests/microformats-v2/h-card/relativeurlsempty.html
@@ -1,4 +1,7 @@
 <base href="http://example.com/profile">
 <div class="h-card">
-  <a class="p-name u-url u-uid" href="">Max Mustermann</a> 
+  <a class="p-name u-url" href="">Max Mustermann</a> 
+
+  <!-- no value attribute, so get text content -->
+  <data class="u-uid">
 </div>


### PR DESCRIPTION
updates tests to match microformats/microformats2-parsing#10 by fixing one broken test in v1/hcard/email, and adding a new test in v2/hcard/relativeurlsempty that will pass only with the new parsing rules implemented.

(this should only be merged once the proposed spec change has been made)