### PR TITLE
Reflect the parsing rules for src and alt attributes on img elements

### DIFF
--- a/tests/microformats-mixed/h-entry/change-log.html
+++ b/tests/microformats-mixed/h-entry/change-log.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>h-card parsing tests</title>
+
+    <link rel="stylesheet" href="../../../css/testsuite.css">
+    <link rel="stylesheet" href="../../../prettify.css">
+
+    <script src="../../../javascript/prettify.js"></script>
+    <script src="../../../javascript/testsuite.js"></script>
+   
+</head>
+<body class="h-feed">
+
+    <h1 class="p-name"><span class="p-x-format">h-entry</span> parsing tests &dash; change logs</h1>
+
+    <p class="p-description">The files in this directory where designed to test the parsing of mark-up which mixes version 1 and 2 microformats. </p>
+    <p class="p-description">Theses are backwards compatibility tests for the older version 1 microformats specification. Please do not use this as a reference for authoring microformats.</p>
+
+    <h2>Change log:</h2>
+    <ul>
+        <!-- Add change log event to the top of this list as a h-entry -->
+        <li class="h-entry">
+            <span class="p-name e-content">Updated JSON in order to reflect the parsing rules for src and alt attributes on img elements</span> &dash;
+            <time class="dt-published" datetime="2019-06-24">24 June 2019</time>
+            by <span class="p-author">Jan Sauer</span>
+        </li>
+        <li class="h-entry">
+            <span class="p-name e-content">Created</span> &dash; 
+            <time class="dt-published" datetime="2012-09-10">7 June 2015</time>
+            by <span class="p-author">Glenn Jones</span>
+        </li>
+    </ul>
+
+    <h2>Contributors:</h2>
+    <ul>
+        <!-- If you Contribute to the test please add yourself as an author using p-author h-card -->
+        <li class="p-author h-card">
+           <a class="u-url p-name" rel="author" href="http://www.glennjones.net/">Glenn Jones</a> 
+        </li>
+        <li class="p-author h-card">
+            <a class="u-url p-name" rel="author" href="https://jansauer.de/">Jan Sauer</a>
+        </li>
+    </ul>
+        
+    <footer>
+        All content and code is released into the <a href="http://en.wikipedia.org/wiki/public_domain">public domain</a>
+    </footer>
+      
+</body>
+</html>

--- a/tests/microformats-mixed/h-entry/mixedroots.json
+++ b/tests/microformats-mixed/h-entry/mixedroots.json
@@ -1,27 +1,44 @@
-
 {
-  "items": [{
-    "type": ["h-entry"],
-    "properties": {
-      "author": [{
-        "value": "Aaron Parecki",
-        "type": ["h-card"],
-        "properties": {
-          "photo": ["https://aaronparecki.com/images/aaronpk.png"],
-          "logo": ["https://aaronparecki.com/images/aaronpk.png"],
-          "url": ["https://aaronparecki.com/"],
-          "uid": ["https://aaronparecki.com/"],
-          "name": ["Aaron Parecki"]
-        }
-      }],
-      "content": [{
-        "value": "Did you play\n    @playmapattackat\n    #realtimeconf? Here is some more info about how we built it!\n    http://pdx.esri.com/blog/2013/10/17/introducting-mapattack/",
-        "html": "Did you play\n    <a href=\"http://twitter.com/playmapattack\">@playmapattack</a>at\n    <a href=\"http://aaronparecki.com/tag/realtimeconf\">#<span class=\"p-category\">realtimeconf</span></a>? Here is some more info about how we built it!\n    <a href=\"http://pdx.esri.com/blog/2013/10/17/introducting-mapattack/\"><span class=\"protocol\">http://</span>pdx.esri.com/blog/2013/10/17/introducting-mapattack/</a>"
-      }],
-      "name": ["Did you play\n    @playmapattackat\n    #realtimeconf? Here is some more info about how we built it!\n    http://pdx.esri.com/blog/2013/10/17/introducting-mapattack/"],
-      "category": ["realtimeconf"]
+  "items": [
+    {
+      "type": ["h-entry"],
+      "properties": {
+        "author": [
+          {
+            "value": "Aaron Parecki",
+            "type": ["h-card"],
+            "properties": {
+              "photo": [
+                {
+                  "alt": "Aaron Parecki",
+                  "value": "https://aaronparecki.com/images/aaronpk.png"
+                }
+              ],
+              "logo": [
+                {
+                  "alt": "Aaron Parecki",
+                  "value": "https://aaronparecki.com/images/aaronpk.png"
+                }
+              ],
+              "url": ["https://aaronparecki.com/"],
+              "uid": ["https://aaronparecki.com/"],
+              "name": ["Aaron Parecki"]
+            }
+          }
+        ],
+        "content": [
+          {
+            "value": "Did you play\n    @playmapattackat\n    #realtimeconf? Here is some more info about how we built it!\n    http://pdx.esri.com/blog/2013/10/17/introducting-mapattack/",
+            "html": "Did you play\n    <a href=\"http://twitter.com/playmapattack\">@playmapattack</a>at\n    <a href=\"http://aaronparecki.com/tag/realtimeconf\">#<span class=\"p-category\">realtimeconf</span></a>? Here is some more info about how we built it!\n    <a href=\"http://pdx.esri.com/blog/2013/10/17/introducting-mapattack/\"><span class=\"protocol\">http://</span>pdx.esri.com/blog/2013/10/17/introducting-mapattack/</a>"
+          }
+        ],
+        "name": [
+          "Did you play\n    @playmapattackat\n    #realtimeconf? Here is some more info about how we built it!\n    http://pdx.esri.com/blog/2013/10/17/introducting-mapattack/"
+        ],
+        "category": ["realtimeconf"]
+      }
     }
-  }],
+  ],
   "rels": {
     "author": ["https://aaronparecki.com/", "https://plus.google.com/117847912875913905493"]
   },

--- a/tests/microformats-v2/h-card/change-log.html
+++ b/tests/microformats-v2/h-card/change-log.html
@@ -13,20 +13,24 @@
 </head>
 <body class="h-feed">
         
-        <h1 class="p-name"><span class="p-x-format">h-card</span> parsing tests &dash; change logs</h1>
+    <h1 class="p-name"><span class="p-x-format">h-card</span> parsing tests &dash; change logs</h1>
 
-           <p class="p-description">The files in this directory where designed to test the parsing of h-card. </p> 
-
+    <p class="p-description">The files in this directory where designed to test the parsing of h-card.</p>
 
     <h2>Change log:</h2>
     <ul>
         <!-- Add change log event to the top of this list as a h-entry -->
-		<li class="h-entry">
+        <li class="h-entry">
+            <span class="p-name e-content">Updated JSON in order to reflect the parsing rules for src and alt attributes on img elements</span> &dash;
+            <time class="dt-published" datetime="2019-06-24">24 June 2019</time>
+            by <span class="p-author">Jan Sauer</span>
+        </li>
+		    <li class="h-entry">
             <span class="p-name e-content">Added test for empty href="" attribute in implied property</span> &dash; 
             <time class="dt-published" datetime="2017-06-3">3 June 2017</time> 
             by <span class="p-author">Sven Knebel</span>
         </li>
-		<li class="h-entry">
+		    <li class="h-entry">
             <span class="p-name e-content">Added test using empty href="" attribute to reference current page</span> &dash; 
             <time class="dt-published" datetime="2017-05-27">27 May 2017</time> 
             by <span class="p-author">Sven Knebel</span>
@@ -88,7 +92,6 @@
         </li>
     </ul>
 
-
     <h2>Contributors:</h2>
     <ul>
         <!-- If you Contribute to the test please add yourself as an author using p-author h-card -->
@@ -98,16 +101,17 @@
         <li class="p-author h-card">
            <a class="u-url p-name" rel="author" href="http://www.glennjones.net/">Glenn Jones</a> 
         </li>
-		<li class="p-author h-card">
-		   <a class="u-url p-name" rel="author" href="https://www.svenknebel.de/">Sven Knebel</a>
-		</li>
+		    <li class="p-author h-card">
+		        <a class="u-url p-name" rel="author" href="https://www.svenknebel.de/">Sven Knebel</a>
+		    </li>
+        <li class="p-author h-card">
+            <a class="u-url p-name" rel="author" href="https://jansauer.de/">Jan Sauer</a>
+        </li>
     </ul>
 
-        
     <footer>
         All content and code is released into the <a href="http://en.wikipedia.org/wiki/public_domain">public domain</a>
     </footer>
       
 </body>
-
 </html>

--- a/tests/microformats-v2/h-card/extendeddescription.json
+++ b/tests/microformats-v2/h-card/extendeddescription.json
@@ -1,15 +1,22 @@
 {
-    "items": [{
-        "type": ["h-card"],
-        "properties": {
-            "photo": ["http://blog.mozilla.org/press/files/2012/04/mitchell-baker.jpg"],
-            "url": ["http://blog.lizardwrangler.com/", "https://twitter.com/MitchellBaker"],
-            "name": ["Mitchell Baker"],
-            "org": ["Mozilla Foundation"],
-            "note": ["Mitchell is responsible for setting the direction and scope of the Mozilla Foundation and its activities."],
-            "category": ["Strategy", "Leadership"]
-        }
-    }],
-    "rels": {},
-    "rel-urls": {}
+  "items": [
+    {
+      "type": ["h-card"],
+      "properties": {
+        "photo": {
+          "alt": "photo of Mitchell",
+          "value": "http://blog.mozilla.org/press/files/2012/04/mitchell-baker.jpg"
+        },
+        "url": ["http://blog.lizardwrangler.com/", "https://twitter.com/MitchellBaker"],
+        "name": ["Mitchell Baker"],
+        "org": ["Mozilla Foundation"],
+        "note": [
+          "Mitchell is responsible for setting the direction and scope of the Mozilla Foundation and its activities."
+        ],
+        "category": ["Strategy", "Leadership"]
+      }
+    }
+  ],
+  "rels": {},
+  "rel-urls": {}
 }

--- a/tests/microformats-v2/h-card/extendeddescription.json
+++ b/tests/microformats-v2/h-card/extendeddescription.json
@@ -3,10 +3,12 @@
     {
       "type": ["h-card"],
       "properties": {
-        "photo": {
-          "alt": "photo of Mitchell",
-          "value": "http://blog.mozilla.org/press/files/2012/04/mitchell-baker.jpg"
-        },
+        "photo": [
+          {
+            "alt": "photo of Mitchell",
+            "value": "http://blog.mozilla.org/press/files/2012/04/mitchell-baker.jpg"
+          }
+        ],
         "url": ["http://blog.lizardwrangler.com/", "https://twitter.com/MitchellBaker"],
         "name": ["Mitchell Baker"],
         "org": ["Mozilla Foundation"],

--- a/tests/microformats-v2/h-entry/change-log.html
+++ b/tests/microformats-v2/h-entry/change-log.html
@@ -13,14 +13,18 @@
 </head>
 <body class="h-feed">
         
-        <h1 class="p-name"><span class="p-x-format">h-entry</span> parsing tests &dash; change logs</h1>
+    <h1 class="p-name"><span class="p-x-format">h-entry</span> parsing tests &dash; change logs</h1>
 
-           <p class="p-description">The files in this directory where designed to test the expanding of relative URLs to absolute URLs in the HTML content of e-* propreties. </p> 
-
+    <p class="p-description">The files in this directory where designed to test the expanding of relative URLs to absolute URLs in the HTML content of e-* propreties.</p>
 
     <h2>Change log:</h2>
     <ul>
         <!-- Add change log event to the top of this list as a h-entry -->
+        <li class="h-entry">
+            <span class="p-name e-content">Updated JSON in order to reflect the parsing rules for src and alt attributes on img elements</span> &dash;
+            <time class="dt-published" datetime="2019-06-24">24 June 2019</time>
+            by <span class="p-author">Jan Sauer</span>
+        </li>
         <li class="h-entry">
             <span class="p-name e-content">Moved from experiemental implied value nested test</span> &dash; 
             <time class="dt-published" datetime="2015-06-08">8 June 2015</time> 
@@ -68,7 +72,6 @@
         </li>
     </ul>
 
-
     <h2>Contributors:</h2>
     <ul>
         <!-- If you Contribute to the test please add yourself as an author using p-author h-card -->
@@ -78,13 +81,14 @@
         <li class="p-author h-card">
            <a class="u-url p-name" rel="author" href="http://www.glennjones.net/">Glenn Jones</a> 
         </li>
+        <li class="p-author h-card">
+            <a class="u-url p-name" rel="author" href="https://jansauer.de/">Jan Sauer</a>
+        </li>
     </ul>
 
-        
     <footer>
         All content and code is released into the <a href="http://en.wikipedia.org/wiki/public_domain">public domain</a>
     </footer>
       
 </body>
-
 </html>

--- a/tests/microformats-v2/h-entry/u-property.json
+++ b/tests/microformats-v2/h-entry/u-property.json
@@ -1,12 +1,29 @@
 {
-    "items": [{
-        "type": ["h-entry"],
-        "properties": {
-            "name": ["microformats.org at 7"],
-            "url": ["http://microformats.org/", "http://microformats.org/2012/06/25/microformats-org-at-7", "http://microformats.org/2012/06/25/microformats-org-at-7", "http://microformats.org/", "http://microformats.org/wiki/microformats2-parsing", "http://microformats.org/wiki/value-class-pattern", "http://microformats.org/wiki/", "http://microformats.org/discuss"],
-            "photo": ["http://example.com/images/logo.gif", "http://example.com/posterimage.jpg"]
-        }
-    }],
-    "rels": {},
-    "rel-urls": {}
+  "items": [
+    {
+      "type": ["h-entry"],
+      "properties": {
+        "name": ["microformats.org at 7"],
+        "url": [
+          "http://microformats.org/",
+          "http://microformats.org/2012/06/25/microformats-org-at-7",
+          "http://microformats.org/2012/06/25/microformats-org-at-7",
+          "http://microformats.org/",
+          "http://microformats.org/wiki/microformats2-parsing",
+          "http://microformats.org/wiki/value-class-pattern",
+          "http://microformats.org/wiki/",
+          "http://microformats.org/discuss"
+        ],
+        "photo": [
+          {
+            "alt": "company logos",
+            "value": "images/logo.gif"
+          },
+          "http://example.com/posterimage.jpg"
+        ]
+      }
+    }
+  ],
+  "rels": {},
+  "rel-urls": {}
 }

--- a/tests/microformats-v2/h-resume/affiliation.json
+++ b/tests/microformats-v2/h-resume/affiliation.json
@@ -1,19 +1,28 @@
 {
-    "items": [{
-        "type": ["h-resume"],
-        "properties": {
-            "name": ["Tim Berners-Lee"],
-            "summary": ["invented the World Wide Web"],
-            "affiliation": [{
-                "type": ["h-card"],
-                "value": "W3C",
-                "properties": {
-                    "name": ["W3C"],
-                    "photo": ["http://www.w3.org/Icons/WWW/w3c_home_nb.png"]
+  "items": [
+    {
+      "type": ["h-resume"],
+      "properties": {
+        "name": ["Tim Berners-Lee"],
+        "summary": ["invented the World Wide Web"],
+        "affiliation": [
+          {
+            "type": ["h-card"],
+            "value": "W3C",
+            "properties": {
+              "name": ["W3C"],
+              "photo": [
+                {
+                  "alt": "W3C",
+                  "value": "http://www.w3.org/Icons/WWW/w3c_home_nb.png"
                 }
-            }]
-        }
-    }],
-    "rels": {},
-    "rel-urls": {}
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "rels": {},
+  "rel-urls": {}
 }

--- a/tests/microformats-v2/h-resume/change-log.html
+++ b/tests/microformats-v2/h-resume/change-log.html
@@ -13,14 +13,18 @@
 </head>
 <body class="h-feed">
         
-        <h1 class="p-name"><span class="p-x-format">h-resume</span> parsing tests &dash; change logs</h1>
+    <h1 class="p-name"><span class="p-x-format">h-resume</span> parsing tests &dash; change logs</h1>
 
-           <p class="p-description">The files in this directory where designed to test the parsing of h-resume. </p> 
-
+    <p class="p-description">The files in this directory where designed to test the parsing of h-resume.</p>
 
     <h2>Change log:</h2>
     <ul>
         <!-- Add change log event to the top of this list as a h-entry -->
+        <li class="h-entry">
+            <span class="p-name e-content">Updated JSON in order to reflect the parsing rules for src and alt attributes img elements</span> -
+            <time class="dt-published" datetime="2019-06-24">24 June 2019</time>
+            by <span class="p-author">Jan Sauer</span>
+        </li>
         <li class="h-entry">
             <span class="p-name e-content">Update text output to be textContent non-trimmed for contact, education and work tests</span> &dash; 
             <time class="dt-published" datetime="2015-05-29">29 May 2015</time> 
@@ -59,20 +63,20 @@
         </li>
     </ul>
 
-
     <h2>Contributors:</h2>
     <ul>
         <!-- If you Contribute to the test please add yourself as an author using p-author h-card -->
         <li class="p-author h-card">
            <a class="u-url p-name" rel="author" href="http://www.glennjones.net/">Glenn Jones</a> 
         </li>
+        <li class="p-author h-card">
+            <a class="u-url p-name" rel="author" href="https://jansauer.de/">Jan Sauer</a>
+        </li>
     </ul>
-
         
     <footer>
         All content and code is released into the <a href="http://en.wikipedia.org/wiki/public_domain">public domain</a>
     </footer>
       
 </body>
-
 </html>


### PR DESCRIPTION
Parsing a `u-` property should return the result of "parse an img
element for src and alt" in case the element is a `img` tag with a
`src` attribute. Based on this sub section `img` tags with a `alt`
attribute should result in a new structure, containing a `value` and
`alt` property.
> http://microformats.org/wiki/microformats2-parsing

This mr updates all tests subject to this rule in order to reflect this.

!!! This mr does not include any updates to the v1 tests nor did i
check if any changes to are needed, as i'm not be familiar with v1
parsing rules !!!