### PR TITLE
Add mixed tests for v2 microformats

### DIFF
--- a/tests/microformats-v2/mixed/change-log.html
+++ b/tests/microformats-v2/mixed/change-log.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>h-review parsing tests</title>
+
+    <link rel="stylesheet" href="../../../css/testsuite.css">
+    <link rel="stylesheet" href="../../../prettify.css">
+
+    <script src="../../../javascript/prettify.js"></script>
+    <script src="../../../javascript/testsuite.js"></script>
+   
+</head>
+<body class="h-feed">
+        
+    <h1 class="p-name"><span class="p-x-format">h-review</span> parsing tests &dash; change logs</h1>
+
+    <p class="p-description">The files in this directory where designed to test parsing rules that are not specific to any particular microformat type but rather apply to all of them.</p>
+
+    <h2>Change log:</h2>
+    <ul>
+        <!-- Add change log event to the top of this list as a h-entry -->
+        <li class="h-entry">
+            <span class="p-name e-content">Created</span> &dash;
+            <time class="dt-published" datetime="2015-05-29">24 June 2019</time>
+            by <span class="p-author">Jan Sauer</span>
+        </li>
+        Created
+    </ul>
+
+    <h2>Contributors:</h2>
+    <ul>
+        <!-- If you Contribute to the test please add yourself as an author using p-author h-card -->
+        <li class="p-author h-card">
+            <a class="u-url p-name" rel="author" href="https://jansauer.de/">Jan Sauer</a>
+        </li>
+    </ul>
+        
+    <footer>
+        All content and code is released into the <a href="http://en.wikipedia.org/wiki/public_domain">public domain</a>
+    </footer>
+      
+</body>
+</html>

--- a/tests/microformats-v2/mixed/ignoretemplate.html
+++ b/tests/microformats-v2/mixed/ignoretemplate.html
@@ -1,0 +1,21 @@
+<div class="h-card">
+  <p>Jan Sauer</p>
+
+  <template class="p-family-name">
+    Invalid
+  </template>
+
+  <span class="p-name">
+    <span class="value">Jan</span>
+    <abbr>H</abbr>
+    <template class="value">Invalid</template>
+  </span>
+
+  <p class="p-org h-card">
+    10M
+    <template class="p-name">
+      Invalid
+    </template>
+  </p>
+
+</div>

--- a/tests/microformats-v2/mixed/ignoretemplate.json
+++ b/tests/microformats-v2/mixed/ignoretemplate.json
@@ -1,0 +1,21 @@
+{
+  "items": [
+    {
+      "type": ["h-card"],
+      "properties": {
+        "name": ["Jan"],
+        "org": [
+          {
+            "type": ["h-card"],
+            "properties": {
+              "name": ["10M"]
+            },
+            "value": "10M"
+          }
+        ]
+      }
+    }
+  ],
+  "rels": {},
+  "rel-urls": {}
+}

--- a/tests/microformats-v2/mixed/vendorprefix.html
+++ b/tests/microformats-v2/mixed/vendorprefix.html
@@ -1,0 +1,18 @@
+<p class="h-card">Valid</p>
+<p class="h-car1d">Invalid</p>
+<p class="h-car_d">Invalid</p>
+<p class="x-card">Invalid</p>
+<p class="x-h-card">Invalid</p>
+
+<p class="h-vendor-card">Valid</p>
+<p class="h-vendor--card">Invalid</p>
+<p class="h-vendor-8card">Invalid</p>
+<p class="h-vendor-card-">Invalid</p>
+
+<p class="h-8-vendor-card">Valid</p>
+<p class="h-8to8-vendor-card">Valid</p>
+
+<p class="h-8to8-ven1or-card">Invalid</p>
+<p class="h-8-8-vendor-card">Invalid</p>
+
+<p class="h-super-extra-long-microformat-type">Valid</p>

--- a/tests/microformats-v2/mixed/vendorprefix.json
+++ b/tests/microformats-v2/mixed/vendorprefix.json
@@ -1,0 +1,36 @@
+{
+  "items": [
+    {
+      "type": ["h-card"],
+      "properties": {
+        "name": ["Valid"]
+      }
+    },
+    {
+      "type": ["h-vendor-card"],
+      "properties": {
+        "name": ["Valid"]
+      }
+    },
+    {
+      "type": ["h-8-vendor-card"],
+      "properties": {
+        "name": ["Valid"]
+      }
+    },
+    {
+      "type": ["h-8to8-vendor-card"],
+      "properties": {
+        "name": ["Valid"]
+      }
+    },
+    {
+      "type": ["h-super-extra-long-microformat-type"],
+      "properties": {
+        "name": ["Valid"]
+      }
+    }
+  ],
+  "rels": {},
+  "rel-urls": {}
+}

--- a/tests/microformats-v2/mixed/vendorprefixproperty.html
+++ b/tests/microformats-v2/mixed/vendorprefixproperty.html
@@ -1,0 +1,19 @@
+<div class="h-card">
+  <p class="p-name">Valid</p>
+  <p class="p-nam1e">Invalid</p>
+  <p class="p-nam_e">Invalid</p>
+  <p class="x-name">Invalid</p>
+  <p class="x-p-name">Invalid</p>
+
+  <p class="p-vendor-name">Valid</p>
+  <p class="p-vendor--name">Invalid</p>
+  <p class="p-vendor-8name">Invalid</p>
+  <p class="p-vendor-name-">Invalid</p>
+
+  <p class="p-8-vendor-name">Valid</p>
+  <p class="p-8to8-vendor-name">Valid</p>
+
+  <p class="p-8to8-ven1or-name">Invalid</p>
+  <p class="p-8-8-vendor-name">Invalid</p>p
+  <p class="p-super-extra-long-microformat-property-name">Valid</p>
+</div>

--- a/tests/microformats-v2/mixed/vendorprefixproperty.json
+++ b/tests/microformats-v2/mixed/vendorprefixproperty.json
@@ -1,0 +1,16 @@
+{
+  "items": [
+    {
+      "type": ["h-card"],
+      "properties": {
+        "name": ["Valid"],
+        "vendor-name": ["Valid"],
+        "8-vendor-name": ["Valid"],
+        "8to8-vendor-name": ["Valid"],
+        "super-extra-long-microformat-property-name": ["Valid"]
+      }
+    }
+  ],
+  "rels": {},
+  "rel-urls": {}
+}


### PR DESCRIPTION
The added tests aim to test parsing rules that apply to all microformat types.
1. ignoring tags that don't end up in the DOM
2. possible microformat types; including usage of vendor prefixes
3. possible property names; including usage of vendor prefixes