### PR TITLE
Add trailing slash to normalized absolute URLs in parsed JSON

### DIFF
--- a/tests/microformats-v2/h-card/change-log.html
+++ b/tests/microformats-v2/h-card/change-log.html
@@ -21,12 +21,17 @@
     <h2>Change log:</h2>
     <ul>
         <!-- Add change log event to the top of this list as a h-entry -->
-		<li class="h-entry">
+        <li class="h-entry">
+            <span class="p-name e-content">Add trailing slash to normalized absolute URLs in parsed JSON</span> &dash; 
+            <time class="dt-published" datetime="2019-08-16">16 August 2019</time> 
+            by <span class="p-author">Jason Garber</span>
+        </li>
+        <li class="h-entry">
             <span class="p-name e-content">Added test for empty href="" attribute in implied property</span> &dash; 
             <time class="dt-published" datetime="2017-06-3">3 June 2017</time> 
             by <span class="p-author">Sven Knebel</span>
         </li>
-		<li class="h-entry">
+        <li class="h-entry">
             <span class="p-name e-content">Added test using empty href="" attribute to reference current page</span> &dash; 
             <time class="dt-published" datetime="2017-05-27">27 May 2017</time> 
             by <span class="p-author">Sven Knebel</span>
@@ -98,9 +103,9 @@
         <li class="p-author h-card">
            <a class="u-url p-name" rel="author" href="http://www.glennjones.net/">Glenn Jones</a> 
         </li>
-		<li class="p-author h-card">
-		   <a class="u-url p-name" rel="author" href="https://www.svenknebel.de/">Sven Knebel</a>
-		</li>
+        <li class="p-author h-card">
+          <a class="u-url p-name" rel="author" href="https://www.svenknebel.de/">Sven Knebel</a>
+        </li>
     </ul>
 
         

--- a/tests/microformats-v2/h-card/impliedphoto.json
+++ b/tests/microformats-v2/h-card/impliedphoto.json
@@ -67,14 +67,14 @@
         "type": ["h-card"],
         "properties": {
             "name": ["John Doe"],
-            "url": ["https://example.com"]
+            "url": ["https://example.com/"]
         }
     },
     {
         "type": ["h-card"],
         "properties": {
             "name": ["John Doe"],
-            "url": ["https://example.com"]
+            "url": ["https://example.com/"]
         }
     }],
     "rels": {},

--- a/tests/microformats-v2/h-entry/change-log.html
+++ b/tests/microformats-v2/h-entry/change-log.html
@@ -22,6 +22,11 @@
     <ul>
         <!-- Add change log event to the top of this list as a h-entry -->
         <li class="h-entry">
+            <span class="p-name e-content">Add trailing slash to normalized absolute URLs in parsed JSON</span> &dash; 
+            <time class="dt-published" datetime="2019-08-16">16 August 2019</time> 
+            by <span class="p-author">Jason Garber</span>
+        </li>
+        <li class="h-entry">
             <span class="p-name e-content">Moved from experiemental implied value nested test</span> &dash; 
             <time class="dt-published" datetime="2015-06-08">8 June 2015</time> 
             by <span class="p-author">Glenn Jones</span>

--- a/tests/microformats-v2/h-entry/impliedvalue-nested.json
+++ b/tests/microformats-v2/h-entry/impliedvalue-nested.json
@@ -10,7 +10,7 @@
                     "author": [{
                         "type": ["h-card"],
                         "properties": {
-                            "url": ["http://example.com"],
+                            "url": ["http://example.com/"],
                             "name": ["Example Author"]
                         },
                         "value": "Example Author"


### PR DESCRIPTION
Referencing [this conversation in #microformats](https://chat.indieweb.org/microformats/2019-08-16#t1565967823698400), I've added trailing slashes in parsed JSON for absolute URLs of type `http://example.com`.

For example, `http://example.com` would normalize to `http://example.com/`. This _should_ conform with URL parsing libraries (e.g. the [Addressable](https://rubygems.org/gems/addressable) Ruby gem) and similar specs (e.g. [IndieAuth user profile URLs](https://indieauth.spec.indieweb.org/#user-profile-url)).

The relevant language from [microformats2-parsing](http://microformats.org/wiki/microformats2-parsing):

> return the normalized absolute URL of the gotten value, following the containing document's language's rules for resolving relative URLs (e.g. in HTML, use the current URL context as determined by the page, and first <base> element, if any).

It's a small but significant change, so feedback is greatly appreciated. Thanks!