### PR TITLE
Normalize example.com URLs in input and output

### DIFF
--- a/tests/microformats-v2/h-card/change-log.html
+++ b/tests/microformats-v2/h-card/change-log.html
@@ -20,6 +20,16 @@
     <h2>Change log:</h2>
     <ul>
         <!-- Add change log event to the top of this list as a h-entry -->
+		    <li class="h-entry">
+            <span class="p-name e-content">Add trailing slash to example.com URLs in JSON output</span> &dash; 
+            <time class="dt-published" datetime="2020-04-20">20 April 2020</time> 
+            by <span class="p-author">Jason Garber</span>
+        </li>
+		    <li class="h-entry">
+            <span class="p-name e-content">Normalize example.com URLs to use http:// scheme</span> &dash; 
+            <time class="dt-published" datetime="2020-04-15">15 April 2020</time> 
+            by <span class="p-author">Jason Garber</span>
+        </li>
         <li class="h-entry">
             <span class="p-name e-content">Correct errors in output impliedname.json</span> &dash; 
             <time class="dt-published" datetime="2020-04-30">30 April 2020</time> 

--- a/tests/microformats-v2/h-card/impliedname.html
+++ b/tests/microformats-v2/h-card/impliedname.html
@@ -20,6 +20,6 @@
 <div class="h-card"> John Doe, <span class="p-org">Mozilla</span> </div>
 
 <!-- drop nested <script> and <style>, replace <img> with alt -->
-<p class="h-card"><style>p{font-color: red;}</style> <span>John</span> <span>Doe</span><script src="https://example.com/script.js"></script> <img src="/photo.jpg" alt="Jr."> </p>
+<p class="h-card"><style>p{font-color: red;}</style> <span>John</span> <span>Doe</span><script src="http://example.com/script.js"></script> <img src="/photo.jpg" alt="Jr."> </p>
 
 <!-- additional implied p-name tests in h-entry/impliedname.html -->

--- a/tests/microformats-v2/h-card/impliedphoto.html
+++ b/tests/microformats-v2/h-card/impliedphoto.html
@@ -10,5 +10,5 @@
 <!-- don't imply photo -->
 <div class="h-card"><img class="h-card" alt="Jane Doe" src="jane.jpeg"/>Jane Doe</div>
 <div class="h-card"><span class="h-card"><object data="jane.jpeg">Jane Doe</object></span></div>
-<div class="h-card"> <a href="https://example.com"><img src="https://example.com/photo.jpg"></a> <span class="p-name">John Doe</span> </div>
-<div class="h-card"> <a href="https://example.com" class="p-name u-url">John Doe <img src="https://example.com/photo.jpg" alt=""> <img src="https://example.com/photo2.jpg" alt=""></a> </div>
+<div class="h-card"> <a href="http://example.com"><img src="http://example.com/photo.jpg"></a> <span class="p-name">John Doe</span> </div>
+<div class="h-card"> <a href="http://example.com" class="p-name u-url">John Doe <img src="http://example.com/photo.jpg" alt=""> <img src="http://example.com/photo2.jpg" alt=""></a> </div>

--- a/tests/microformats-v2/h-card/impliedphoto.json
+++ b/tests/microformats-v2/h-card/impliedphoto.json
@@ -87,14 +87,14 @@
         "type": ["h-card"],
         "properties": {
             "name": ["John Doe"],
-            "url": ["https://example.com"]
+            "url": ["http://example.com"]
         }
     },
     {
         "type": ["h-card"],
         "properties": {
             "name": ["John Doe"],
-            "url": ["https://example.com"]
+            "url": ["http://example.com"]
         }
     }],
     "rels": {},

--- a/tests/microformats-v2/h-card/impliedphoto.json
+++ b/tests/microformats-v2/h-card/impliedphoto.json
@@ -87,14 +87,14 @@
         "type": ["h-card"],
         "properties": {
             "name": ["John Doe"],
-            "url": ["http://example.com"]
+            "url": ["http://example.com/"]
         }
     },
     {
         "type": ["h-card"],
         "properties": {
             "name": ["John Doe"],
-            "url": ["http://example.com"]
+            "url": ["http://example.com/"]
         }
     }],
     "rels": {},

--- a/tests/microformats-v2/h-entry/change-log.html
+++ b/tests/microformats-v2/h-entry/change-log.html
@@ -21,6 +21,11 @@
     <ul>
         <!-- Add change log event to the top of this list as a h-entry -->
         <li class="h-entry">
+            <span class="p-name e-content">Add trailing slash to example.com URLs in JSON output</span> &dash; 
+            <time class="dt-published" datetime="2020-04-20">20 April 2020</time> 
+            by <span class="p-author">Jason Garber</span>
+        </li>
+        <li class="h-entry">
             <span class="p-name e-content">Updated JSON in order to reflect the parsing rules for src and alt attributes on img elements</span> &dash;
             <time class="dt-published" datetime="2019-06-24">24 June 2019</time>
             by <span class="p-author">Jan Sauer</span>

--- a/tests/microformats-v2/h-entry/impliedvalue-nested.json
+++ b/tests/microformats-v2/h-entry/impliedvalue-nested.json
@@ -10,7 +10,7 @@
                     "author": [{
                         "type": ["h-card"],
                         "properties": {
-                            "url": ["http://example.com"],
+                            "url": ["http://example.com/"],
                             "name": ["Example Author"]
                         },
                         "value": "Example Author"

--- a/tests/microformats-v2/h-recipe/all.json
+++ b/tests/microformats-v2/h-recipe/all.json
@@ -42,7 +42,7 @@
                 "type": ["h-card"],
                 "properties": {
                     "name": ["Glenn Jones"],
-                    "url": ["http://glennjones.net"]
+                    "url": ["http://glennjones.net/"]
                 }
             }]
         }

--- a/tests/microformats-v2/h-recipe/change-log.html
+++ b/tests/microformats-v2/h-recipe/change-log.html
@@ -21,6 +21,11 @@
     <h2>Change log:</h2>
     <ul>
         <!-- Add change log event to the top of this list as a h-entry -->
+        <li class="h-entry">
+            <span class="p-name e-content">Add trailing slash to glennjones.net URL in JSON output</span> &dash; 
+            <time class="dt-published" datetime="2020-04-21">21 April 2020</time> 
+            by <span class="p-author">Jason Garber</span>
+        </li>
          <li class="h-entry">
             <span class="p-name e-content">Update text output to be textContent non-trimmed for all test</span> &dash; 
             <time class="dt-published" datetime="2015-05-29">29 May 2015</time> 


### PR DESCRIPTION
There were a few cases where HTML input and JSON output mixed schemes for URLs like `http://example.com` and `https://example.com` and where the URL in the JSON output lacked a trailing slash.

This PR normalizes on `http://` since it's the more widely-used protocol in the remainder of the test suite and adds a trailing slash in cases where the resulting value is `http://example.com/`.