### PR TITLE
Update JSON output to comply with Parsing Specification Section 1.5

### DIFF
--- a/tests/microformats-v2/h-card/change-log.html
+++ b/tests/microformats-v2/h-card/change-log.html
@@ -21,6 +21,11 @@
     <ul>
         <!-- Add change log event to the top of this list as a h-entry -->
         <li class="h-entry">
+            <span class="p-name e-content">Update JSON output to reflect the parsing rules for src and alt attributes on img elements</span> &dash; 
+            <time class="dt-published" datetime="2020-04-29">29 April 2020</time> 
+            by <span class="p-author">Jason Garber</span>
+        </li>
+        <li class="h-entry">
             <span class="p-name e-content">Updated JSON in order to reflect the parsing rules for src and alt attributes on img elements</span> &dash;
             <time class="dt-published" datetime="2019-06-24">24 June 2019</time>
             by <span class="p-author">Jan Sauer</span>

--- a/tests/microformats-v2/h-card/change-log.html
+++ b/tests/microformats-v2/h-card/change-log.html
@@ -21,6 +21,11 @@
     <ul>
         <!-- Add change log event to the top of this list as a h-entry -->
         <li class="h-entry">
+            <span class="p-name e-content">Update hyperlinkedphoto.json output to reflect the parsing rules for src and alt attributes on img elements</span> &dash; 
+            <time class="dt-published" datetime="2020-04-30">30 April 2020</time> 
+            by <span class="p-author">Jason Garber</span>
+        </li>
+        <li class="h-entry">
             <span class="p-name e-content">Update JSON output to reflect the parsing rules for src and alt attributes on img elements</span> &dash; 
             <time class="dt-published" datetime="2020-04-29">29 April 2020</time> 
             by <span class="p-author">Jason Garber</span>

--- a/tests/microformats-v2/h-card/hyperlinkedphoto.json
+++ b/tests/microformats-v2/h-card/hyperlinkedphoto.json
@@ -3,7 +3,12 @@
         "type": ["h-card"],
         "properties": {
             "name": ["Rohit Khare"],
-            "photo": ["http://example.com/images/photo.gif"],
+            "photo": [
+                {
+                    "alt": "Rohit Khare",
+                    "value": "http://example.com/images/photo.gif"
+                }
+            ],
             "url": ["http://rohit.khare.org/"]
         }
     }],

--- a/tests/microformats-v2/h-card/impliedname.json
+++ b/tests/microformats-v2/h-card/impliedname.json
@@ -3,7 +3,12 @@
         "type": ["h-card"],
         "properties": {
             "name": ["Jane Doe"],
-            "photo": ["http://example.com/jane.html"]
+            "photo": [
+                {
+                    "alt": "Jane Doe",
+                    "value": "http://example.com/jane.html"
+                }
+            ]
         }
     },
     {
@@ -23,7 +28,12 @@
         "type": ["h-card"],
         "properties": {
             "name": ["Jane Doe"],
-            "photo": ["http://example.com/jane.html"]
+            "photo": [
+                {
+                    "alt": "Jane Doe",
+                    "value": "http://example.com/jane.html"
+                }
+            ]
         }
     },
     {
@@ -43,7 +53,12 @@
         "type": ["h-card"],
         "properties": {
             "name": ["Jane Doe"],
-            "photo": ["http://example.com/jane.html"]
+            "photo": [
+                {
+                    "alt": "Jane Doe",
+                    "value": "http://example.com/jane.html"
+                }
+            ]
         }
     },
     {
@@ -66,7 +81,12 @@
             "type": ["h-card"],
             "properties": {
                 "name": ["John Doe"],
-                "photo": ["http://example.com/john.html"]
+                "photo": [
+                    {
+                        "alt": "Jane Doe",
+                        "value": "http://example.com/jane.html"
+                    }
+                ]
             }
         }]
     },
@@ -77,7 +97,12 @@
             "type": ["h-card"],
             "properties": {
                 "name": ["John Doe"],
-                "photo": ["http://example.com/john.html"]
+                "photo": [
+                    {
+                        "alt": "Jane Doe",
+                        "value": "http://example.com/jane.html"
+                    }
+                ]
             }
         }]
     },
@@ -101,7 +126,12 @@
         "type": ["h-card"],
         "properties": {
             "name": ["John Doe Jr."],
-            "photo": ["http://example.com/photo.jpg"]
+            "photo": [
+                {
+                    "alt": "Jr.",
+                    "value": "http://example.com/photo.jpg"
+                }
+            ]
         }
     }],
     "rels": {},

--- a/tests/microformats-v2/h-card/impliedphoto.json
+++ b/tests/microformats-v2/h-card/impliedphoto.json
@@ -3,7 +3,12 @@
         "type": ["h-card"],
         "properties": {
             "name": ["Jane Doe"],
-            "photo": ["http://example.com/jane.jpeg"]
+            "photo": [
+                {
+                    "alt": "Jane Doe",
+                    "value": "http://example.com/jane.jpeg"
+                }
+            ]
         }
     },
     {
@@ -17,7 +22,12 @@
         "type": ["h-card"],
         "properties": {
             "name": ["Jane Doe"],
-            "photo": ["http://example.com/jane.jpeg"]
+            "photo": [
+                {
+                    "alt": "Jane Doe",
+                    "value": "http://example.com/jane.jpeg"
+                }
+            ]
         }
     },
     {
@@ -31,7 +41,12 @@
         "type": ["h-card"],
         "properties": {
             "name": ["Jane Doe"],
-            "photo": ["http://example.com/jane.jpeg"]
+            "photo": [
+                {
+                    "alt": "Jane Doe",
+                    "value": "http://example.com/jane.jpeg"
+                }
+            ]
         }
     },
     {
@@ -48,7 +63,12 @@
             "type": ["h-card"],
             "properties": {
                 "name": ["Jane Doe"],
-                "photo": ["http://example.com/jane.jpeg"]
+                "photo": [
+                    {
+                        "alt": "Jane Doe",
+                        "value": "http://example.com/jane.jpeg"
+                    }
+                ]
             }
         }]
     },

--- a/tests/microformats-v2/h-review/change-log.html
+++ b/tests/microformats-v2/h-review/change-log.html
@@ -22,6 +22,11 @@
     <ul>
         <!-- Add change log event to the top of this list as a h-entry -->
         <li class="h-entry">
+            <span class="p-name e-content">Update JSON output to reflect the parsing rules for src and alt attributes on img elements</span> &dash; 
+            <time class="dt-published" datetime="2020-04-29">29 April 2020</time> 
+            by <span class="p-author">Jason Garber</span>
+        </li>
+        <li class="h-entry">
             <span class="p-name e-content">Update text output to be textContent non-trimmed for implieditem, vcard and item tests</span> &dash; 
             <time class="dt-published" datetime="2015-05-29">29 May 2015</time> 
             by <span class="p-author">Glenn Jones</span>

--- a/tests/microformats-v2/h-review/photo.json
+++ b/tests/microformats-v2/h-review/photo.json
@@ -3,7 +3,12 @@
         "type": ["h-review"],
         "properties": {
             "name": ["Crepes on Cole"],
-            "photo": ["http://example.com/images/photo.gif"]
+            "photo": [
+              {
+                "alt": "Crepes on Cole",
+                "value": "http://example.com/images/photo.gif"
+              }
+            ]
         }
     }],
     "rels": {},


### PR DESCRIPTION
This PR is a follow up from #109 that I uncovered while testing. Adds the appropriate structures to output JSON files when parsing an `img` element with `alt` and `src` attributes.

See [Section 1.5 of the microformats2 parsing specification](http://microformats.org/wiki/microformats2-parsing#parse_an_img_element_for_src_and_alt). The changed files reflect the parsing rules for implied photos which reference Section 1.5.

Quote below, emphasis added:

> if no explicit "photo" property, and no other explicit `u-*` properties, and no nested microformats,
> then imply by:
> if `img.h-x[src]`, then **use the result of "parse an img element for src and alt" (see Sec.1.5)** for photo
> else if `object.h-x[data]` then use `data` for photo
> else if `.h-x>img[src]:only-of-type:not[.h-*]` then **use the result of "parse an img element for src and alt" (see Sec.1.5)** for photo
> else if `.h-x>object[data]:only-of-type:not[.h-*]` then use that `object`’s `data` for photo
> else if `.h-x>:only-child:not[.h-*]>img[src]:only-of-type:not[.h-*]`, then **use the result of "parse an img element for src and alt" (see Sec.1.5)** for photo
> else if `.h-x>:only-child:not[.h-*]>object[data]:only-of-type:not[.h-*]`, then use that `object`’s data for photo
> if there is a gotten photo value, return the normalized absolute URL of it, following the containing document's language's rules for resolving relative URLs (e.g. in HTML, use the current URL context as determined by the page, and first `<base>` element, if any).