### PR TITLE
Remove single space from h-entry/urlincontent test

### DIFF
--- a/tests/microformats-v2/h-entry/urlincontent.json
+++ b/tests/microformats-v2/h-entry/urlincontent.json
@@ -4,7 +4,7 @@
         "properties": {
             "name": ["Expanding URLs within HTML content"],
             "content": [{
-                "value": "Should not change: http://www.w3.org/\n            Should not change: http://example.com/\n            File relative: test.html = http://example.com/test.html\n            Directory relative: /test/test.html = http://example.com/test/test.html\n            Relative to root: /test.html = http://example.com/test.html\n        \n         http://example.com/images/photo.gif",
+                "value": "Should not change: http://www.w3.org/\n            Should not change: http://example.com/\n            File relative: test.html = http://example.com/test.html\n            Directory relative: /test/test.html = http://example.com/test/test.html\n            Relative to root: /test.html = http://example.com/test.html\n        \n        http://example.com/images/photo.gif",
                 "html": "<ul>\n            <li><a href=\"http://www.w3.org/\">Should not change: http://www.w3.org/</a></li>\n            <li><a href=\"http://example.com/\">Should not change: http://example.com/</a></li>\n            <li><a href=\"http://example.com/test.html\">File relative: test.html = http://example.com/test.html</a></li>\n            <li><a href=\"http://example.com/test/test.html\">Directory relative: /test/test.html = http://example.com/test/test.html</a></li>\n            <li><a href=\"http://example.com/test.html\">Relative to root: /test.html = http://example.com/test.html</a></li>\n        </ul>\n        <img src=\"http://example.com/images/photo.gif\">"
             }]
         }


### PR DESCRIPTION
As can be clearly seen in the `html` property of `content`, there are exactly 8 spaces between the `\n` and the start of the `<img>`. For some reason the plain text output was showing 9 spaces. Removed one.