### PR TITLE
Correct dependencies in package.json and remove NPM reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,6 @@ This group of tests was built to test microformats parsers. The individual tests
 The tests are broken into sets within the tests directory of this project. They are first grouped by version. Some parsers only support a single version of microformats. They are then subdivided by the type of microformat i.e. h-card.
 
 
-## NPM
-
-The test have been added to npm (Node Package Manager) and the latest version can be add to a project using the following command:
-
-    npm i microformat-tests --save
-
-
 ## Contributing new tests or updating tests
 
 This set of test belongs to the microformats community. If you find any errors in the current test or new patterns you believe should be in the test suite please feel free to send a pull request. 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@ This group of tests was built to test microformats parsers. The individual tests
 
 The tests are broken into sets within the tests directory of this project. They are first grouped by version. Some parsers only support a single version of microformats. They are then subdivided by the type of microformat i.e. h-card.
 
+## NPM
+
+To add the latest microformats test suite to your project using npm, run the following command:
+
+`npm install microformats/tests --save-dev`
+
+Update to the latest microformats test suite with the following command:
+
+`npm update microformats/tests`
+
+
 
 ## Contributing new tests or updating tests
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "dependencies": {
+  "devDependencies": {
     "blipp": "2.1.x",
     "boom": "2.7.x",
     "good": "6.1.x",


### PR DESCRIPTION
### Correct `dependencies` to `devDependencies`

The `dependencies` of this package are only required for the development of the package itself and these are not required by any project that wishes to use this as a dependency. As such, they should be listed as `devDependencies` to prevent them from being installed in dependent projects. 

### Remove NPM reference from README

The npm package has not been published in 5 years and is severely out-of-date. Mentioning it here is no longer helpful. 

https://www.npmjs.com/package/microformat-tests