### PR TITLE
Update expected rels order

### DIFF
--- a/tests/microformats-v1/hreview/vcard.json
+++ b/tests/microformats-v1/hreview/vcard.json
@@ -47,7 +47,7 @@
     },
     "http://example.com/crepe": {
       "text": "http://example.com/crepe",
-      "rels": ["self", "bookmark"]
+      "rels": ["bookmark", "self"]
     },
     "http://en.wikipedia.org/wiki/Wikipedia:Text_of_Creative_Commons_Attribution-ShareAlike_3.0_Unported_License": {
       "text": "Creative Commons Attribution-ShareAlike License",


### PR DESCRIPTION
Per the last line of [parse a hyperlink element for rel microformats
](https://microformats.org/wiki/microformats2-parsing#parse_a_hyperlink_element_for_rel_microformats)

> set the value of that "rels" key to an array of all unique items in the set of rel values unioned with the current array value of the "rels" key, sorted alphabetically.

I checked other tests and this appears to be the only one where they weren't alphabetical.